### PR TITLE
fix pos substrings

### DIFF
--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -316,17 +316,16 @@ int ESP8266WebServer::_parseArgumentsPrivate(const String& data, int counted) {
       key_end_pos = next_index;
     if (key_end_pos == -1)
       key_end_pos = data.length();
-    key_end_pos--;
 
     // handle key/value
-    if (key_end_pos >= (int)pos) {
+    if ( (int)pos <= key_end_pos) {
       // do not store or count empty ending key ("url?x=y;")
 
       if (counted > 0) {
         RequestArgument& arg = _currentArgs[arg_total];
         arg.key = urlDecode(data.substring(pos, key_end_pos));
         if ((equal_index != -1) && ((equal_index < next_index - 1) || (next_index == -1)))
-          arg.value = urlDecode(data.substring(equal_index + 1, next_index - 1));
+          arg.value = urlDecode(data.substring(equal_index + 1, next_index));
 #ifdef DEBUG_ESP_HTTP_SERVER
         DEBUG_OUTPUT.print("arg ");
         DEBUG_OUTPUT.print(arg_total);


### PR DESCRIPTION
key_end_pos--;
dont count down here, it will cut of every key by -1 ("save" will be "sav") (substring  (end = up to, but not including, so no need to -1)

Parsing cpp L329
arg.value = urlDecode(data.substring(equal_index + 1, next_index - 1));
=> -1 is too less for substring (substring  (end = up to, but not including, so no need to -1)