### PR TITLE
Proposed changes from review

### DIFF
--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -4,7 +4,6 @@
 #include <functional>
 
 #define SCHEDULED_FN_MAX_COUNT 32
-#define SCHEDULED_FN_INITIAL_COUNT 4
 
 // This API was not considered stable but is now stabilizing.
 // Function signatures may change, queue must stay FIFO.

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -17,11 +17,13 @@
 // Note: there is no mechanism for cancelling scheduled functions.
 // Keep that in mind when binding functions to objects which may have short lifetime.
 // Returns false if the number of scheduled functions exceeds SCHEDULED_FN_MAX_COUNT.
+//bool schedule_function(std::function<void(void)>&& fn);
 bool schedule_function(const std::function<void(void)>& fn);
 
 // Run given function periodically about every <repeat_us> microseconds until it returns false.
 // Note that it may be more than <repeat_us> microseconds between calls if `yield` is not called
 // frequently, and therefore should not be used for timing critical operations.
+//bool schedule_function_us(std::function<bool(void)>&& fn, uint32_t repeat_us);
 bool schedule_function_us(const std::function<bool(void)>& fn, uint32_t repeat_us);
 
 // Run all scheduled functions.


### PR DESCRIPTION
It's too much to put into words, and giving you source code that compiles should be so much nicer.
What's in it:
- initialize to nullptr instead of 0, explicitly initialize mNext in places.
- eliminate sLastUnused, that's completely redundant.
- "<" is often safer than "!=" : `sCount < SCHEDULED_FN_MAX_COUNT`
- place recycle_fn() call into "critical section", obviates additional lock.
- move and copy semantics for schedule_function*() (move is commented in header, relies on YET ANOTHER separate PR https://github.com/esp8266/Arduino/pull/6129 )
- please don't mention formatting, it's. beyond. my. control.
- in run_scheduled_functions, when there are rescheduled items before AND after an item that's done, the preceding mNext should be made to point to the next following item, instead of left dangling.